### PR TITLE
Simpler multi-platform support for pybind_extension targets.

### DIFF
--- a/native_lib/python/BUILD.bazel
+++ b/native_lib/python/BUILD.bazel
@@ -16,9 +16,6 @@ py_test(
     size = "small",
     srcs = ["foo_test.py"],
     python_version = "PY3",
-    data = select({
-      "@platforms//os:windows": [":myfoo.pyd"],
-      "//conditions:default": [":myfoo.so"],
-    }),
+    deps = [":myfoo"],
     tags = ["unit"],
 )

--- a/patches/pybind11_bazel.patch
+++ b/patches/pybind11_bazel.patch
@@ -13,7 +13,7 @@ index cde1e93..e8dba55 100644
          copts = copts + PYBIND_COPTS + select({
              "@pybind11//:msvc_compiler": [],
              "//conditions:default": [
-@@ -59,6 +63,33 @@ def pybind_extension(
+@@ -59,6 +63,41 @@ def pybind_extension(
          **kwargs
      )
  
@@ -41,6 +41,14 @@ index cde1e93..e8dba55 100644
 +        srcs = [name + ".dll"],
 +        outs = [name + ".pyd"],
 +        cmd = "cp $< $@"
++    )
++
++    native.py_library(
++        name = name,
++        data = select({
++            "@platforms//os:windows": [":" + name + ".pyd"],
++            "//conditions:default": [":" + name + ".so"],
++        })
 +    )
 +
 +


### PR DESCRIPTION
Modified the pybind_extension() rule definition so that it creates a target with the original name that switches between .pyd and .so depending on the target platform. This way, py_library() targets do not need to use the select() function to pick the right version.

Tested on Linux. I expect Mac and Windows to work as well, but I don't have a way to test them.