### PR TITLE
Make visibility in the pybind_extension() py_library() rule explicit.

### DIFF
--- a/patches/pybind11_bazel.patch
+++ b/patches/pybind11_bazel.patch
@@ -2,7 +2,15 @@ diff --git a/build_defs.bzl b/build_defs.bzl
 index cde1e93..e8dba55 100644
 --- a/build_defs.bzl
 +++ b/build_defs.bzl
-@@ -41,6 +41,10 @@ def pybind_extension(
+@@ -35,6 +35,7 @@ def pybind_extension
+         linkopts = [],
+         tags = [],
+         deps = [],
++        visibility = None,
+         **kwargs):
+     # Mark common dependencies as required for build_cleaner.
+     tags = tags + ["req_dep=%s" % dep for dep in PYBIND_DEPS]
+@@ -41,6 +42,11 @@ def pybind_extension(
  
      native.cc_binary(
          name = name + ".so",
@@ -10,10 +18,11 @@ index cde1e93..e8dba55 100644
 +          "@platforms//os:windows": ["@platforms//:incompatible"],
 +          "//conditions:default": [],
 +        }),
++        visibility = visibility,
          copts = copts + PYBIND_COPTS + select({
              "@pybind11//:msvc_compiler": [],
              "//conditions:default": [
-@@ -59,6 +63,42 @@ def pybind_extension(
+@@ -59,6 +65,44 @@ def pybind_extension(
          **kwargs
      )
  
@@ -29,6 +38,7 @@ index cde1e93..e8dba55 100644
 +        linkshared = 1,
 +        tags = tags,
 +        deps = deps + PYBIND_DEPS,
++        visibility = visibility,
 +        **kwargs
 +    )
 +
@@ -40,16 +50,17 @@ index cde1e93..e8dba55 100644
 +        }),
 +        srcs = [name + ".dll"],
 +        outs = [name + ".pyd"],
-+        cmd = "cp $< $@"
++        cmd = "cp $< $@",
++        visibility = visibility,
 +    )
 +
 +    native.py_library(
 +        name = name,
-+        visibility = ["//visibility:public"],
 +        data = select({
 +            "@platforms//os:windows": [":" + name + ".pyd"],
 +            "//conditions:default": [":" + name + ".so"],
-+        })
++        }),
++        visibility = visibility,
 +    )
 +
 +


### PR DESCRIPTION
The rule pybind_extension() now takes the visibility explicitly, and passes it unchanged
to all targets it creates. This is a non-change for the binary rules (before, visibility
would be passed through **kwargs, now we pass it explicitly), and it will give the same
visibility also to the new py_library().